### PR TITLE
Remove usages of lval as an expression

### DIFF
--- a/src/render/MarkdownRenderer.php
+++ b/src/render/MarkdownRenderer.php
@@ -201,7 +201,8 @@ class MarkdownRenderer extends Renderer<string> {
 
   <<__Override>>
   protected function renderListOfItems(Blocks\ListOfItems $node): string {
-    $this_list = ++$this->numberOfLists;
+    $this->numberOfLists++;
+    $this_list = $this->numberOfLists;
     return $node->getItems()
       |> Vec\map(
         $$,


### PR DESCRIPTION
Summary: required for .hhconfig disable_lval_as_an_expression.
