### PR TITLE
Introduce markdown environment

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -1,0 +1,63 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\Markdown;
+
+final class Environment<T> {
+  public function __construct(
+    private ParserContext $parser,
+    private RenderContext $context,
+    private Renderer<T> $renderer,
+  ) {}
+
+  public function getParser(): ParserContext {
+    return $this->parser;
+  }
+
+  public function getContext(): RenderContext {
+    return $this->context;
+  }
+
+  public function getRenderer(): Renderer<T> {
+    return $this->renderer;
+  }
+
+  public function getInlineContext(): Inlines\Context {
+    return $this->parser->getInlineContext();
+  }
+
+  public function getBlockContext(): UnparsedBlocks\Context {
+    return $this->parser->getBlockContext();
+  }
+
+  public function getFilters(): Container<RenderFilter> {
+    return $this->context->getFilters();
+  }
+
+  public function use(Plugin $plugin): void {
+    $this->getBlockContext()
+      ->prependBlockTypes(...$plugin->getBlockProducers());
+    $this->getInlineContext()
+      ->prependInlineTypes(...$plugin->getInlineTypes());
+    $this->getContext()->appendFilters(...$plugin->getRenderFilters());
+  }
+
+  public function parse(string $markdown): ASTNode {
+    return parse($this->parser, $markdown);
+  }
+
+  public function render(ASTNode $markdown): T {
+    return $this->renderer->render($markdown);
+  }
+
+  public function convert(string $markdown): T {
+    return $this->render($this->parse($markdown));
+  }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,35 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\Markdown;
+
+abstract class Plugin {
+  /**
+   * @see Facebook\Markdown\RenderContext::appendFilters()
+   */
+  public function getRenderFilters(): Container<RenderFilter> {
+    return vec[];
+  }
+
+  /**
+   * @see Facebook\Markdown\Inlines\Context::prependInlineTypes()
+   */
+  public function getInlineTypes(): Container<classname<Inlines\Inline>> {
+    return vec[];
+  }
+
+  /**
+   * @see Facebook\Markdown\UnparsedBlocks\Context::prependBlockTypes()
+   */
+  public function getBlockProducers(
+  ): Container<classname<UnparsedBlocks\BlockProducer>> {
+    return vec[];
+  }
+}

--- a/src/html_environment.php
+++ b/src/html_environment.php
@@ -1,0 +1,29 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\Markdown;
+
+function html_environment(): Environment<string> {
+  $parser = new ParserContext();
+  $context = new RenderContext();
+  $renderer = new HTMLRenderer($context);
+
+  return new Environment($parser, $context, $renderer);
+}
+
+function unsafe_html_environment(): Environment<string> {
+  $parser = new ParserContext();
+  $context = new RenderContext();
+  $renderer = new HTMLRenderer($context);
+
+  $parser->enableHTML_UNSAFE();
+
+  return new Environment($parser, $context, $renderer);
+}


### PR DESCRIPTION
continuing #7 

changes;
- setters have been removed.
- extension has been renamed to plugin, as extension has been used previously to describe render filters, this ensures there's no confusion between the two.
- static methods have been moved the functions instead
- html method has been split into two to remove the boolean flag.
