### PR TITLE
Require hhvm 4.128 and support autoloading with ext_watchman

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 tests/ export-ignore
 .hhconfig export-ignore
+.hhvmconfig.hdf export-ignore

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         hhvm:
-          - '4.102'
+          - '4.128'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ vendor/
 *.orig
 composer.lock
 .*.hhast.*cache
+.var/
 composer.phar

--- a/.hhvmconfig.hdf
+++ b/.hhvmconfig.hdf
@@ -1,0 +1,3 @@
+Autoload {
+  Query = {"expression": ["allof", ["type", "f"], ["suffix", ["anyof", "hack", "php"]], ["not",["anyof",["dirname",".var"],["dirname",".git"]]]]}
+}

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
         "hhvm/hhvm-autoload": "^2.0|^3.0",
         "facebook/fbexpect": "^2.1.0",
         "hhvm/hhast": "^4.0"
+    },
+    "config": {
+      "allow-plugins": {
+        "hhvm/hhvm-autoload": true
+      }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
       }
     },
     "require": {
-        "hhvm": "^4.102",
-        "hhvm/hsl": "^4.0",
+        "hhvm": "^4.128",
         "hhvm/type-assert": "^3.1|^4.0"
     },
     "require-dev": {

--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -5,5 +5,6 @@
   "devRoots": [
     "tests/"
   ],
-  "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler"
+  "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler",
+  "useFactsIfAvailable": true
 }

--- a/src/inlines/AutoLinkExtension.php
+++ b/src/inlines/AutoLinkExtension.php
@@ -20,7 +20,12 @@ class AutoLinkExtension extends AutoLink {
   const string PREFIX = 'www\.|'.self::SCHEME.'|'.self::EMAIL;
 
   const keyset<string> MUST_FOLLOW = keyset[
-    "\n", ' ', '*', '_', '~', '(',
+    "\n",
+    ' ',
+    '*',
+    '_',
+    '~',
+    '(',
   ];
 
   <<__Override>>
@@ -35,15 +40,14 @@ class AutoLinkExtension extends AutoLink {
     int $offset,
   ): ?(Inline, int) {
     if (
-      $offset > 0
-      && !C\contains_key(self::MUST_FOLLOW, $markdown[$offset - 1])
+      $offset > 0 && !C\contains_key(self::MUST_FOLLOW, $markdown[$offset - 1])
     ) {
       return null;
     }
 
     $string = Str\slice($markdown, $offset);
 
-    $matches = darray[];
+    $matches = dict[];
     $result = \preg_match_with_matches(
       '/^(?<prefix>'.self::PREFIX.')(?<domain>'.self::DOMAIN.')/i',
       $string,
@@ -66,30 +70,28 @@ class AutoLinkExtension extends AutoLink {
     if (Str\lowercase($prefix) === 'www.') {
       list($path, $offset) = self::consumePath($markdown, $offset);
       $text = $prefix.$domain.$path;
-      return tuple(
-        new self($text, 'http://'.$text),
-        $offset,
-      );
+      return tuple(new self($text, 'http://'.$text), $offset);
     }
     if (Str\ends_with($prefix, '://')) {
       list($path, $offset) = self::consumePath($markdown, $offset);
       $text = $prefix.$domain.$path;
-      return tuple(
-        new self($text, $text),
-        $offset,
-      );
+      return tuple(new self($text, $text), $offset);
     }
 
     // email
-    return tuple(
-      new self($full, 'mailto:'.$full),
-      $offset,
-    );
+    return tuple(new self($full, 'mailto:'.$full), $offset);
   }
 
   // From GFM spec
   const keyset<string> TRAILING_PUNCTUATION = keyset[
-    '?', '!', '.', ',', ':', '*', '_', '~',
+    '?',
+    '!',
+    '.',
+    ',',
+    ':',
+    '*',
+    '_',
+    '~',
   ];
 
   private static function consumePath(
@@ -132,11 +134,7 @@ class AutoLinkExtension extends AutoLink {
     if ($last === ';') {
       $idx = Str\search_last($match, '&');
       if ($idx !== null) {
-        $slice = Str\slice(
-          $match,
-          $idx + 1,
-          $len -  ($idx + 2),
-        );
+        $slice = Str\slice($match, $idx + 1, $len - ($idx + 2));
         if (\ctype_alnum($slice)) {
           $match = Str\slice($match, 0, $idx);
           if ($match === '') {

--- a/src/inlines/RawHTML.php
+++ b/src/inlines/RawHTML.php
@@ -15,9 +15,7 @@ use namespace HH\Lib\Str;
 
 <<__ConsistentConstruct>>
 class RawHTML extends Inline {
-  public function __construct(
-    private string $content,
-  ) {
+  public function __construct(private string $content) {
   }
 
   public function getContent(): string {
@@ -31,10 +29,7 @@ class RawHTML extends Inline {
 
   // From the GFM spec
   const string OPEN_TAG =
-    '<'.HTMLBlock::TAG_NAME.
-    '('.HTMLBlock::ATTRIBUTE.')*'.
-    '\\s*'.
-    '\\/?>';
+    '<'.HTMLBlock::TAG_NAME.'('.HTMLBlock::ATTRIBUTE.')*'.'\\s*'.'\\/?>';
   const string CLOSING_TAG = '<\\/'.HTMLBlock::TAG_NAME.'\\s*>';
   const string DECLARATION = '<![A-Z]+\\s+[^>]+>';
 
@@ -53,26 +48,23 @@ class RawHTML extends Inline {
 
     $slice = Str\slice($string, $offset);
 
-    $matches = darray[];
+    $matches = dict[];
     if (
       \preg_match_with_matches(
         '/^('.self::OPEN_TAG.'|'.self::CLOSING_TAG.'|'.self::DECLARATION.')/i',
         $slice,
         inout $matches,
-      ) === 1
+      ) ===
+        1
     ) {
       $match = $matches[0];
       $offset += Str\length($match);
-      return tuple(
-        new self($match),
-        $offset,
-      );
+      return tuple(new self($match), $offset);
     }
 
-    return
-      self::consumeHtmlComment($string, $offset)
-      ?? self::consumeProcessingInstruction($string, $offset)
-      ?? self::consumeCDataSection($string, $offset);
+    return self::consumeHtmlComment($string, $offset) ??
+      self::consumeProcessingInstruction($string, $offset) ??
+      self::consumeCDataSection($string, $offset);
   }
 
   private static function consumeHtmlComment(

--- a/src/render/MarkdownRenderer.php
+++ b/src/render/MarkdownRenderer.php
@@ -316,7 +316,7 @@ class MarkdownRenderer extends Renderer<string> {
       return \mb_encode_numericentity(
         $node->getContent(),
         // start, end, offset, mask
-        varray[0, 0xffff, 0, 0xffff],
+        vec[0, 0xffff, 0, 0xffff],
         'UTF-8',
       );
     }


### PR DESCRIPTION
The hsl is always built-in.
ext_watchman and HH\Facts are always available.
varray eq vec and darray eq dict is always true.
All legacy arrays have been replaced with Hack arrays.